### PR TITLE
Fix singlepart direct upload

### DIFF
--- a/dvuploader/directupload.py
+++ b/dvuploader/directupload.py
@@ -235,11 +235,7 @@ async def _upload_singlepart(
     params = {
         "headers": headers,
         "url": ticket["url"],
-        "data": file_sender(
-            file_name=filepath,
-            progress=progress,
-            pbar=pbar,
-        ),
+        "data": open(filepath, "rb"),
     }
 
     async with session.put(**params) as response:

--- a/dvuploader/dvuploader.py
+++ b/dvuploader/dvuploader.py
@@ -41,6 +41,7 @@ class DVUploader(BaseModel):
         dataverse_url: str,
         api_token: str,
         n_parallel_uploads: int = 1,
+        force_native: bool = False,
     ) -> None:
         """
         Uploads the files to the specified Dataverse repository in parallel.
@@ -98,7 +99,7 @@ class DVUploader(BaseModel):
             persistent_id=persistent_id,
         )
 
-        if not has_direct_upload:
+        if not has_direct_upload and not force_native:
             rich.print(
                 "\n[bold italic white]⚠️  Direct upload not supported. Falling back to Native API."
             )
@@ -107,7 +108,7 @@ class DVUploader(BaseModel):
 
         progress, pbars = self.setup_progress_bars(files=files)
 
-        if not has_direct_upload:
+        if not has_direct_upload or force_native:
             with progress:
                 asyncio.run(
                     native_upload(

--- a/dvuploader/dvuploader.py
+++ b/dvuploader/dvuploader.py
@@ -59,6 +59,7 @@ class DVUploader(BaseModel):
         print("\n")
         info = "\n".join(
             [
+                f"Server: [bold]{dataverse_url}[/bold]",  # type: ignore
                 f"PID: [bold]{persistent_id}[/bold]",  # type: ignore
                 f"Files: {len(self.files)}",
             ]
@@ -207,6 +208,9 @@ class DVUploader(BaseModel):
         table.add_column("Action")
 
         to_remove = []
+        over_threshold = len(self.files) > 50
+        n_new_files = 0
+        n_skip_files = 0
 
         for file in self.files:
             has_same_hash = any(
@@ -214,11 +218,13 @@ class DVUploader(BaseModel):
             )
 
             if has_same_hash and file.checksum:
+                n_skip_files += 1
                 table.add_row(
                     file.fileName, "[bright_black]Same hash", "[bright_black]Skip"
                 )
                 to_remove.append(file)
             else:
+                n_new_files += 1
                 table.add_row(
                     file.fileName, "[spring_green3]New", "[spring_green3]Upload"
                 )
@@ -231,6 +237,14 @@ class DVUploader(BaseModel):
             self.files.remove(file)
 
         console = Console()
+
+        if over_threshold:
+            table = Table(title="[bold white]🔎 Checking dataset files")
+
+            table.add_column("New", style="spring_green3", no_wrap=True)
+            table.add_column("Skipped", style="bright_black", no_wrap=True)
+            table.add_row(str(n_new_files), str(n_skip_files))
+
         console.print(table)
 
     @staticmethod

--- a/dvuploader/dvuploader.py
+++ b/dvuploader/dvuploader.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from rich.progress import Progress, TaskID
 from rich.table import Table
 from rich.console import Console
+from rich.panel import Panel
 
 from dvuploader.directupload import (
     TICKET_ENDPOINT,
@@ -53,7 +54,23 @@ class DVUploader(BaseModel):
         Returns:
             None
         """
-        # Validate and hash files
+
+        print("\n")
+        info = "\n".join(
+            [
+                f"PID: [bold]{persistent_id}[/bold]",  # type: ignore
+                f"Files: {len(self.files)}",
+            ]
+        )
+
+        panel = Panel(
+            info,
+            title="[bold]DVUploader[/bold]",
+            expand=False,
+        )
+
+        rich.print(panel)
+
         asyncio.run(self._validate_and_hash_files())
 
         # Check for duplicates
@@ -127,15 +144,35 @@ class DVUploader(BaseModel):
             None
         """
 
-        rich.print("\n[italic white]📝 Preparing upload\n")
+        print("\n")
 
-        tasks = [self._validate_and_hash_file(file=file) for file in self.files]
+        progress = Progress()
+        task = progress.add_task(
+            "[bold italic white]📦 Preparing upload[/bold italic white]",
+            total=len(self.files),
+        )
+        with progress:
+            tasks = [
+                self._validate_and_hash_file(
+                    file=file,
+                    progress=progress,
+                    task_id=task,
+                )
+                for file in self.files
+            ]
 
-        await asyncio.gather(*tasks)
+            await asyncio.gather(*tasks)
+
+        print("\n")
 
     @staticmethod
-    async def _validate_and_hash_file(file: File):
+    async def _validate_and_hash_file(
+        file: File,
+        progress: Progress,
+        task_id: TaskID,
+    ):
         file.extract_filename_hash_file()
+        progress.update(task_id, advance=1)
 
     def _check_duplicates(
         self,

--- a/dvuploader/file.py
+++ b/dvuploader/file.py
@@ -1,7 +1,7 @@
 import os
-from typing import List, Optional
+from typing import List, Optional, Union
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 import rich
 
 from dvuploader.checksum import Checksum, ChecksumTypes
@@ -31,6 +31,8 @@ class File(BaseModel):
 
     """
 
+    model_config: ConfigDict = ConfigDict(populate_by_alias=True)
+
     filepath: str = Field(..., exclude=True)
     description: str = ""
     directoryLabel: str = ""
@@ -42,7 +44,7 @@ class File(BaseModel):
     fileName: Optional[str] = None
     checksum: Optional[Checksum] = None
     to_replace: bool = False
-    file_id: Optional[str] = None
+    file_id: Optional[Union[str, int]] = Field(default=None, alias="fileToReplaceId")
 
     def extract_filename_hash_file(self):
         """

--- a/dvuploader/nativeupload.py
+++ b/dvuploader/nativeupload.py
@@ -49,6 +49,7 @@ async def native_upload(
         "headers": {"X-Dataverse-key": api_token},
         "connector": aiohttp.TCPConnector(
             limit=n_parallel_uploads,
+            timeout_ceil_threshold=120,
         ),
     }
 

--- a/dvuploader/packaging.py
+++ b/dvuploader/packaging.py
@@ -6,7 +6,7 @@ from typing import List, Tuple
 MAXIMUM_PACKAGE_SIZE = int(
     os.environ.get(
         "DVUPLOADER_MAX_PKG_SIZE",
-        1024**3,  # 1 GB
+        2 * 1024**3,  # 2 GB
     )
 )
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -122,6 +122,20 @@ yarl = ">=1.0,<2.0"
 speedups = ["Brotli", "aiodns", "brotlicffi"]
 
 [[package]]
+name = "aiohttp-retry"
+version = "2.8.3"
+description = "Simple retry client for aiohttp"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "aiohttp_retry-2.8.3-py3-none-any.whl", hash = "sha256:3aeeead8f6afe48272db93ced9440cf4eda8b6fd7ee2abb25357b7eb28525b45"},
+    {file = "aiohttp_retry-2.8.3.tar.gz", hash = "sha256:9a8e637e31682ad36e1ff9f8bcba912fcfc7d7041722bc901a4b948da4d71ea9"},
+]
+
+[package.dependencies]
+aiohttp = "*"
+
+[[package]]
 name = "aiosignal"
 version = "1.3.1"
 description = "aiosignal: a list of registered asynchronous callbacks"
@@ -1621,4 +1635,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "83742e56b6f9f9c7faf9fd2cbc1b5579144004d18da7fc167e9a98ad4731e199"
+content-hash = "a7be3c5b05dd92578271298fb689b183fc5c4a27bc25a63e0ee1d2273126baf0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -122,20 +122,6 @@ yarl = ">=1.0,<2.0"
 speedups = ["Brotli", "aiodns", "brotlicffi"]
 
 [[package]]
-name = "aiohttp-retry"
-version = "2.8.3"
-description = "Simple retry client for aiohttp"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "aiohttp_retry-2.8.3-py3-none-any.whl", hash = "sha256:3aeeead8f6afe48272db93ced9440cf4eda8b6fd7ee2abb25357b7eb28525b45"},
-    {file = "aiohttp_retry-2.8.3.tar.gz", hash = "sha256:9a8e637e31682ad36e1ff9f8bcba912fcfc7d7041722bc901a4b948da4d71ea9"},
-]
-
-[package.dependencies]
-aiohttp = "*"
-
-[[package]]
 name = "aiosignal"
 version = "1.3.1"
 description = "aiosignal: a list of registered asynchronous callbacks"
@@ -1329,6 +1315,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1635,4 +1622,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a7be3c5b05dd92578271298fb689b183fc5c4a27bc25a63e0ee1d2273126baf0"
+content-hash = "83742e56b6f9f9c7faf9fd2cbc1b5579144004d18da7fc167e9a98ad4731e199"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ nest-asyncio = "^1.5.8"
 aiofiles = "^23.2.1"
 rich = "^13.7.0"
 ipywidgets = "^8.1.1"
-aiohttp-retry = "^2.8.3"
 
 [tool.poetry.scripts]
 dvuploader = "dvuploader.cli:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ nest-asyncio = "^1.5.8"
 aiofiles = "^23.2.1"
 rich = "^13.7.0"
 ipywidgets = "^8.1.1"
+aiohttp-retry = "^2.8.3"
 
 [tool.poetry.scripts]
 dvuploader = "dvuploader.cli:app"

--- a/tests/integration/test_native_upload.py
+++ b/tests/integration/test_native_upload.py
@@ -53,3 +53,50 @@ class TestNativeUpload:
 
             assert len(files) == 3
             assert sorted([file["label"] for file in files]) == sorted(expected_files)
+
+    def test_forced_native_upload(
+        self,
+        credentials,
+    ):
+        BASE_URL, API_TOKEN = credentials
+
+        with tempfile.TemporaryDirectory() as directory:
+            # Arrange
+            create_mock_file(directory, "small_file.txt", size=1)
+            create_mock_file(directory, "mid_file.txt", size=50)
+            create_mock_file(directory, "large_file.txt", size=200)
+
+            # Add all files in the directory
+            files = add_directory(directory=directory)
+
+            # Create Dataset
+            pid = create_dataset(
+                parent="Root",
+                server_url=BASE_URL,
+                api_token=API_TOKEN,
+            )
+
+            # Act
+            uploader = DVUploader(files=files)
+            uploader.upload(
+                persistent_id=pid,
+                api_token=API_TOKEN,
+                dataverse_url=BASE_URL,
+                n_parallel_uploads=1,
+                force_native=True,
+            )
+
+            # Assert
+            expected_files = [
+                "small_file.txt",
+                "mid_file.txt",
+                "large_file.txt",
+            ]
+            files = retrieve_dataset_files(
+                dataverse_url=BASE_URL,
+                persistent_id=pid,
+                api_token=API_TOKEN,
+            )
+
+            assert len(files) == 3
+            assert sorted([file["label"] for file in files]) == sorted(expected_files)

--- a/tests/unit/test_directupload.py
+++ b/tests/unit/test_directupload.py
@@ -1,6 +1,7 @@
 from urllib.parse import urljoin
 import aiohttp
 import pytest
+from rich.progress import Progress
 from dvuploader.directupload import (
     _add_file_to_ds,
     UPLOAD_ENDPOINT,
@@ -25,15 +26,23 @@ class Test_AddFileToDs:
         pid = "persistent_id"
         fpath = "tests/fixtures/add_dir_files/somefile.txt"
         file = File(filepath=fpath)
+        progress = Progress()
+        pbar = progress.add_task("Uploading", total=1)
 
         # Invoke the function
-        result = await _add_file_to_ds(session, dataverse_url, pid, file)
+        result = await _add_file_to_ds(
+            session=session,
+            dataverse_url=dataverse_url,
+            pid=pid,
+            file=file,
+            progress=progress,
+            pbar=pbar,
+        )
 
         # Assert that the response status is 200 and the result is True
         assert mock_post.called_with(
             urljoin(dataverse_url, UPLOAD_ENDPOINT + pid), data=mocker.ANY
         )
-        assert result is True
 
     @pytest.mark.asyncio
     async def test_successfully_replace_file_with_valid_filepath(self, mocker):
@@ -47,16 +56,24 @@ class Test_AddFileToDs:
         pid = "persistent_id"
         fpath = "tests/fixtures/add_dir_files/somefile.txt"
         file = File(filepath=fpath, file_id="0")
+        progress = Progress()
+        pbar = progress.add_task("Uploading", total=1)
 
         # Invoke the function
-        result = await _add_file_to_ds(session, dataverse_url, pid, file)
+        result = await _add_file_to_ds(
+            session=session,
+            dataverse_url=dataverse_url,
+            pid=pid,
+            file=file,
+            progress=progress,
+            pbar=pbar,
+        )
 
         # Assert that the response status is 200 and the result is True
         assert mock_post.called_with(
             urljoin(dataverse_url, REPLACE_ENDPOINT.format(FILE_ID=file.file_id)),
             data=mocker.ANY,
         )
-        assert result is True
 
 
 class Test_ValidateTicketResponse:

--- a/tests/unit/test_directupload.py
+++ b/tests/unit/test_directupload.py
@@ -3,9 +3,9 @@ import aiohttp
 import pytest
 from rich.progress import Progress
 from dvuploader.directupload import (
-    _add_file_to_ds,
     UPLOAD_ENDPOINT,
     REPLACE_ENDPOINT,
+    _add_files_to_ds,
     _validate_ticket_response,
 )
 
@@ -25,16 +25,16 @@ class Test_AddFileToDs:
         dataverse_url = "https://example.com"
         pid = "persistent_id"
         fpath = "tests/fixtures/add_dir_files/somefile.txt"
-        file = File(filepath=fpath)
+        files = [File(filepath=fpath)]
         progress = Progress()
         pbar = progress.add_task("Uploading", total=1)
 
         # Invoke the function
-        result = await _add_file_to_ds(
+        await _add_files_to_ds(
             session=session,
             dataverse_url=dataverse_url,
             pid=pid,
-            file=file,
+            files=files,
             progress=progress,
             pbar=pbar,
         )
@@ -55,23 +55,23 @@ class Test_AddFileToDs:
         dataverse_url = "https://example.com"
         pid = "persistent_id"
         fpath = "tests/fixtures/add_dir_files/somefile.txt"
-        file = File(filepath=fpath, file_id="0")
+        files = [File(filepath=fpath, file_id="0")]
         progress = Progress()
         pbar = progress.add_task("Uploading", total=1)
 
         # Invoke the function
-        result = await _add_file_to_ds(
+        await _add_files_to_ds(
             session=session,
             dataverse_url=dataverse_url,
             pid=pid,
-            file=file,
+            files=files,
             progress=progress,
             pbar=pbar,
         )
 
         # Assert that the response status is 200 and the result is True
         assert mock_post.called_with(
-            urljoin(dataverse_url, REPLACE_ENDPOINT.format(FILE_ID=file.file_id)),
+            urljoin(dataverse_url, REPLACE_ENDPOINT + pid),
             data=mocker.ANY,
         )
 


### PR DESCRIPTION
**Overview**

In issue #7, it was highlighted and discussed that direct upload of a single file (not multipart) to an S3 storage raises a `Not implemented` exception on AWS side. This issue is related to streaming files for POSTing to the S3 storage. To tackle this issue, the `file_sender` function has been removed and replaced with a simple `open` function to upload a file. Additionally, this PR introduces some printing enhancements and allows to force native upload.

**Changes** 

* Use `open` instead of `file_sender` for file uploads.
* Use a progress bar for file preparation to indicate hashing progress (useful if there are many files).
* Option to force native upload, even when direct upload is activated.
* If more than 50 files are uploaded, progress bars are removed upon finishing.

**Closes**

closes #7 