### PR TITLE
Set `image_tag` to `alpha`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Run Dataverse Action
         id: dataverse
         uses: gdcc/dataverse-action@main
+        with:
+          image_tag: alpha
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Due to the [Dataverse Action]() being broken (refer to https://github.com/gdcc/dataverse-action/issues/11), this PR sets the `image_tag` of the testing workflow to `alpha` to ensure tests are running.