### PR TITLE
Support multiple `IO` types

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ import dvuploader as dv
 # Add file individually
 files = [
     dv.File(filepath="./small.txt"),
-    dv.File(directoryLabel="some/dir", filepath="./medium.txt"),
-    dv.File(directoryLabel="some/dir", filepath="./big.txt"),
+    dv.File(directory_label="some/dir", filepath="./medium.txt"),
+    dv.File(directory_label="some/dir", filepath="./big.txt"),
     *dv.add_directory("./data"), # Add an entire directory
 ]
 
@@ -88,7 +88,7 @@ Alternatively, you can also supply a `config` file that contains all necessary i
 * `api_token`: API token of the Dataverse instance.
 * `files`: List of files to upload. Each file is a dictionary with the following keys:
   * `filepath`: Path to the file to upload.
-  * `directoryLabel`: Optional directory label to upload the file to.
+  * `directory_label`: Optional directory label to upload the file to.
   * `description`: Optional description of the file.
   * `mimetype`: Mimetype of the file.
   * `categories`: Optional list of categories to assign to the file.
@@ -104,9 +104,9 @@ api_token: XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
 files:
     - filepath: ./small.txt
     - filepath: ./medium.txt
-      directoryLabel: some/dir
+      directory_label: some/dir
     - filepath: ./big.txt
-      directoryLabel: some/dir
+      directory_label: some/dir
 ```
 
 The `config` file can then be used as follows:

--- a/dvuploader/dvuploader.py
+++ b/dvuploader/dvuploader.py
@@ -108,7 +108,8 @@ class DVUploader(BaseModel):
                 "\n[bold italic white]⚠️  Direct upload not supported. Falling back to Native API."
             )
 
-        rich.print(f"\n[bold italic white]🚀 Uploading files\n")
+        if self.verbose:
+            rich.print(f"\n[bold italic white]🚀 Uploading files\n")
 
         progress, pbars = self.setup_progress_bars(files=files)
 
@@ -292,7 +293,7 @@ class DVUploader(BaseModel):
 
         # Find the file that matches label and directory_label
         for ds_file in ds_files:
-            dspath = os.path.join(ds_file.get("directory_label", ""), ds_file["label"])
+            dspath = os.path.join(ds_file.get("directoryLabel", ""), ds_file["label"])
             fpath = os.path.join(file.directory_label, file.file_name)  # type: ignore
 
             if dspath == fpath:
@@ -320,7 +321,7 @@ class DVUploader(BaseModel):
             file.checksum.value == hash_value
             and file.checksum.type == hash_algo
             and file.file_name == dsFile["label"]
-            and file.directory_label == dsFile.get("directory_label", "")
+            and file.directory_label == dsFile.get("directoryLabel", "")
         )
 
     @staticmethod

--- a/dvuploader/file.py
+++ b/dvuploader/file.py
@@ -1,7 +1,9 @@
+from io import BytesIO, StringIO
 import os
-from typing import List, Optional, Union
+from typing import List, Optional, Union, IO
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic.fields import PrivateAttr
 import rich
 
 from dvuploader.checksum import Checksum, ChecksumTypes
@@ -14,52 +16,66 @@ class File(BaseModel):
     Attributes:
         filepath (str): The path to the file.
         description (str): The description of the file.
-        directoryLabel (str): The label of the directory where the file is stored.
+        directory_label (str): The label of the directory where the file is stored.
         mimeType (str): The MIME type of the file.
         categories (List[str]): The categories associated with the file.
         restrict (bool): Indicates if the file is restricted.
         checksum_type (ChecksumTypes): The type of checksum used for the file.
         storageIdentifier (Optional[str]): The identifier of the storage where the file is stored.
-        fileName (Optional[str]): The name of the file.
+        file_name (Optional[str]): The name of the file.
         checksum (Optional[Checksum]): The checksum of the file.
         to_replace (bool): Indicates if the file should be replaced.
         file_id (Optional[str]): The ID of the file.
 
     Methods:
         _validate_filepath(path): Validates if the file path exists and is a file.
-        _extract_filename_hash_file(): Extracts the filename from the filepath and calculates the file's checksum.
+        _extract_file_name_hash_file(): Extracts the file_name from the filepath and calculates the file's checksum.
 
     """
 
-    model_config: ConfigDict = ConfigDict(populate_by_alias=True)
+    model_config = ConfigDict(
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+    )
 
     filepath: str = Field(..., exclude=True)
+    handler: Union[BytesIO, StringIO, IO, None] = Field(default=None, exclude=True)
     description: str = ""
-    directoryLabel: str = ""
+    directory_label: str = Field(default="", alias="directoryLabel")
     mimeType: str = "text/plain"
     categories: List[str] = ["DATA"]
     restrict: bool = False
     checksum_type: ChecksumTypes = Field(default=ChecksumTypes.MD5, exclude=True)
     storageIdentifier: Optional[str] = None
-    fileName: Optional[str] = None
+    file_name: Optional[str] = Field(default=None, alias="fileName")
     checksum: Optional[Checksum] = None
     to_replace: bool = False
     file_id: Optional[Union[str, int]] = Field(default=None, alias="fileToReplaceId")
 
-    def extract_filename_hash_file(self):
+    _size: int = PrivateAttr(default=0)
+
+    def extract_file_name_hash_file(self):
         """
-        Extracts the filename and calculates the hash of the file.
+        Extracts the file_name and calculates the hash of the file.
 
         Returns:
             self: The current instance of the class.
         """
-        self._validate_filepath(self.filepath)
-        self.fileName = os.path.basename(self.filepath)
 
         # Hash file
         hash_algo, hash_fun = self.checksum_type.value
+
+        if self.handler is None:
+            self._validate_filepath(self.filepath)
+            self.handler = open(self.filepath, "rb")
+            self._size = os.path.getsize(self.filepath)
+        else:
+            self._size = len(self.handler.read())
+            self.handler.seek(0)
+
+        self.file_name = os.path.basename(self.filepath)
         self.checksum = Checksum.from_file(
-            fpath=self.filepath,
+            handler=self.handler,
             hash_fun=hash_fun,
             hash_algo=hash_algo,
         )

--- a/dvuploader/file.py
+++ b/dvuploader/file.py
@@ -71,6 +71,7 @@ class File(BaseModel):
             self._size = os.path.getsize(self.filepath)
         else:
             self._size = len(self.handler.read())
+            self.directory_label = os.path.dirname(self.filepath)
             self.handler.seek(0)
 
         self.file_name = os.path.basename(self.filepath)

--- a/dvuploader/nativeupload.py
+++ b/dvuploader/nativeupload.py
@@ -177,7 +177,7 @@ async def _single_native_upload(
     json_data = {
         "description": file.description,
         "forceReplace": True,
-        "directory_label": file.directory_label,
+        "directoryLabel": file.directory_label,
         "categories": file.categories,
         "restrict": file.restrict,
         "forceReplace": True,

--- a/dvuploader/packaging.py
+++ b/dvuploader/packaging.py
@@ -27,23 +27,22 @@ def distribute_files(dv_files: List["File"]):  # type: ignore
     package_index = 0
     current_size = 0
     for file in dv_files:
-        file_size = os.path.getsize(file.filepath)
 
-        if file_size > MAXIMUM_PACKAGE_SIZE:
+        if file._size > MAXIMUM_PACKAGE_SIZE:
             current_package, current_size, package_index = _append_and_reset(
                 (package_index, [file]),
                 packages,
             )
             continue
 
-        if current_size + file_size > MAXIMUM_PACKAGE_SIZE:
+        if current_size + file._size > MAXIMUM_PACKAGE_SIZE:
             current_package, current_size, package_index = _append_and_reset(
                 (package_index, current_package),
                 packages,
             )
 
         current_package.append(file)
-        current_size += os.path.getsize(file.filepath)
+        current_size += file._size
     else:
         if current_package:
             _append_and_reset(
@@ -91,9 +90,9 @@ def zip_files(
 
     with zipfile.ZipFile(path, "w") as zip_file:
         for file in files:
-            zip_file.write(
-                file.filepath,
-                arcname=_create_arcname(file),
+            zip_file.writestr(
+                data=file.handler.read(),
+                zinfo_or_arcname=_create_arcname(file),
             )
 
     return path
@@ -109,7 +108,7 @@ def _create_arcname(file: "File"):  # type: ignore
     Returns:
         str: The arcname for the given file.
     """
-    if file.directoryLabel is not None:
-        return os.path.join(file.directoryLabel, file.fileName)  # type: ignore
+    if file.directory_label is not None:
+        return os.path.join(file.directory_label, file.file_name)  # type: ignore
     else:
-        return file.fileName
+        return file.file_name

--- a/dvuploader/utils.py
+++ b/dvuploader/utils.py
@@ -72,7 +72,7 @@ def retrieve_dataset_files(
 def add_directory(
     directory: str,
     ignore: List[str] = [r"^\."],
-    directory_label: str = "",
+    rootDirectoryLabel: str = "",
 ):
     """
     Recursively adds all files in the specified directory to a list of File objects.
@@ -80,7 +80,7 @@ def add_directory(
     Args:
         directory (str): The directory path.
         ignore (List[str], optional): A list of regular expressions to ignore certain files or directories. Defaults to [r"^\."].
-        directory_label (str, optional): The label to be added to the directory path of each file. Defaults to "".
+        rootDirectoryLabel (str, optional): The label to be added to the directory path of each file. Defaults to "".
 
     Returns:
         List[File]: A list of File objects representing the files in the directory.
@@ -96,7 +96,7 @@ def add_directory(
         if any(part_is_ignored(part, ignore) for part in list(file.parts)):
             continue
 
-        directoryLabel = _truncate_path(
+        directory_label = _truncate_path(
             file.parent,
             pathlib.Path(directory),
         )
@@ -105,8 +105,8 @@ def add_directory(
             File(
                 filepath=str(file),
                 directoryLabel=os.path.join(
+                    rootDirectoryLabel,
                     directory_label,
-                    directoryLabel,
                 ),
             )
         )
@@ -152,7 +152,7 @@ def part_is_ignored(part, ignore):
 
 
 def setup_pbar(
-    fpath: str,
+    file: File,
     progress: Progress,
 ) -> int:
     """
@@ -166,10 +166,11 @@ def setup_pbar(
         int: The task ID of the progress bar.
     """
 
-    file_size = os.path.getsize(fpath)
-    fname = os.path.basename(fpath)
+    file_size = file._size
+    fname = file.file_name
 
     return progress.add_task(
         f"[pink]├── {fname}",
+        start=True,
         total=file_size,
     )

--- a/tests/fixtures/cli_input.yaml
+++ b/tests/fixtures/cli_input.yaml
@@ -2,6 +2,6 @@ persistent_id: doi:10.70122/XXX/XXXXX
 dataverse_url: https://demo.dataverse.org/
 api_token: XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
 files:
-    - filepath: ./tests/fixtures/add_dir_files/somefile.txt
-    - filepath: ./tests/fixtures/add_dir_files/anotherfile.txt
-      directoryLabel: some/dir
+  - filepath: ./tests/fixtures/add_dir_files/somefile.txt
+  - filepath: ./tests/fixtures/add_dir_files/anotherfile.txt
+    directory_label: some/dir

--- a/tests/integration/test_native_upload.py
+++ b/tests/integration/test_native_upload.py
@@ -1,7 +1,9 @@
+from io import BytesIO
 import tempfile
 
 import pytest
 from dvuploader.dvuploader import DVUploader
+from dvuploader.file import File
 
 from dvuploader.utils import add_directory, retrieve_dataset_files
 from tests.conftest import create_dataset, create_mock_file
@@ -100,3 +102,47 @@ class TestNativeUpload:
 
             assert len(files) == 3
             assert sorted([file["label"] for file in files]) == sorted(expected_files)
+
+
+    def test_native_upload_by_handler(
+        self,
+        credentials,
+    ):
+        BASE_URL, API_TOKEN = credentials
+
+        # Arrange
+        byte_string = b"Hello, World!"
+        files = [
+            File(filepath="subdir/file.txt", handler=BytesIO(byte_string)),
+            File(filepath="biggerfile.txt", handler=BytesIO(byte_string*10000)),
+        ]
+
+        # Create Dataset
+        pid = create_dataset(
+            parent="Root",
+            server_url=BASE_URL,
+            api_token=API_TOKEN,
+        )
+
+        # Act
+        uploader = DVUploader(files=files)
+        uploader.upload(
+            persistent_id=pid,
+            api_token=API_TOKEN,
+            dataverse_url=BASE_URL,
+            n_parallel_uploads=1,
+        )
+
+        # Assert
+        expected_files = [
+            "file.txt",
+            "biggerfile.txt",
+        ]
+        files = retrieve_dataset_files(
+            dataverse_url=BASE_URL,
+            persistent_id=pid,
+            api_token=API_TOKEN,
+        )
+
+        assert len(files) == 2
+        assert sorted([file["label"] for file in files]) == sorted(expected_files)

--- a/tests/integration/test_native_upload.py
+++ b/tests/integration/test_native_upload.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+import json
 import tempfile
 
 import pytest
@@ -42,16 +43,17 @@ class TestNativeUpload:
             )
 
             # Assert
-            expected_files = [
-                "small_file.txt",
-                "mid_file.txt",
-                "large_file.txt",
-            ]
             files = retrieve_dataset_files(
                 dataverse_url=BASE_URL,
                 persistent_id=pid,
                 api_token=API_TOKEN,
             )
+
+            expected_files = [
+                "small_file.txt",
+                "mid_file.txt",
+                "large_file.txt",
+            ]
 
             assert len(files) == 3
             assert sorted([file["label"] for file in files]) == sorted(expected_files)
@@ -89,16 +91,17 @@ class TestNativeUpload:
             )
 
             # Assert
-            expected_files = [
-                "small_file.txt",
-                "mid_file.txt",
-                "large_file.txt",
-            ]
             files = retrieve_dataset_files(
                 dataverse_url=BASE_URL,
                 persistent_id=pid,
                 api_token=API_TOKEN,
             )
+
+            expected_files = [
+                "small_file.txt",
+                "mid_file.txt",
+                "large_file.txt",
+            ]
 
             assert len(files) == 3
             assert sorted([file["label"] for file in files]) == sorted(expected_files)
@@ -134,10 +137,11 @@ class TestNativeUpload:
         )
 
         # Assert
-        expected_files = [
-            "file.txt",
-            "biggerfile.txt",
+        expected = [
+            ("", "biggerfile.txt"),
+            ("subdir", "file.txt"),
         ]
+
         files = retrieve_dataset_files(
             dataverse_url=BASE_URL,
             persistent_id=pid,
@@ -145,4 +149,10 @@ class TestNativeUpload:
         )
 
         assert len(files) == 2
-        assert sorted([file["label"] for file in files]) == sorted(expected_files)
+
+        for ex_dir, ex_f in expected:
+
+            file = next(file for file in files if file["label"] == ex_f)
+
+            assert file["label"] == ex_f, f"File label does not match for file {json.dumps(file)}"
+            assert file.get("directoryLabel", "") == ex_dir, f"Directory label does not match for file {json.dumps(file)}"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -14,7 +14,7 @@ class TestParseYAMLConfig:
 
         # Act
         cli_input = _parse_yaml_config(fpath)
-        [file.extract_filename_hash_file() for file in cli_input.files]
+        [file.extract_file_name_hash_file() for file in cli_input.files]
 
         # Assert
         expected_files = [
@@ -28,7 +28,7 @@ class TestParseYAMLConfig:
 
         assert len(cli_input.files) == 2
         assert sorted(
-            [(file.directoryLabel, file.fileName) for file in cli_input.files]
+            [(file.directory_label, file.file_name) for file in cli_input.files]
         ) == sorted(expected_files)
 
 
@@ -74,7 +74,7 @@ class TestCLIMain:
                 "files": [
                     {
                         "filepath": "./tests/fixtures/add_dir_files/somefile.txt",
-                        "directoryLabel": "",
+                        "directory_label": "",
                     }
                 ],
             }

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -74,7 +74,7 @@ class TestCLIMain:
                 "files": [
                     {
                         "filepath": "./tests/fixtures/add_dir_files/somefile.txt",
-                        "directory_label": "",
+                        "directoryLabel": "",
                     }
                 ],
             }

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -10,13 +10,13 @@ class TestFile:
         # Act
         file = File(
             filepath=fpath,
-            directoryLabel="",
+            directory_label="",
         )
 
-        file.extract_filename_hash_file()
+        file.extract_file_name_hash_file()
 
         # Assert
-        assert file.fileName == "somefile.txt"
+        assert file.file_name == "somefile.txt"
 
     def test_read_non_existent_file(self):
         # Arrange
@@ -26,10 +26,10 @@ class TestFile:
         with pytest.raises(FileNotFoundError):
             file = File(
                 filepath=fpath,
-                directoryLabel="",
+                directory_label="",
             )
 
-            file.extract_filename_hash_file()
+            file.extract_file_name_hash_file()
 
     def test_read_non_file(self):
         # Arrange
@@ -39,7 +39,7 @@ class TestFile:
         with pytest.raises(IsADirectoryError):
             file = File(
                 filepath=fpath,
-                directoryLabel="",
+                directory_label="",
             )
 
-            file.extract_filename_hash_file()
+            file.extract_file_name_hash_file()


### PR DESCRIPTION
**Overview**

This pull request introduces the possibility of passing other `IO` objects, such as `BytesIO` or `StringIO`, alongside local files.


**Example** 

```python
from dvuploader import File, DVUploader
from io import BytesIO

handler = BytesIO(b"some file data")
file = File(
    filepath="somefile.txt",
    handler=handler,
)

uploader = DVUploader(files=[file])
uploader.upload(
    persistent_id="<persistent_id>",
    api_token="<api_token>",
    dataverse_url="<dataverse_url>",
)
```