### PR TITLE
Set file meta after native upload

### DIFF
--- a/tests/integration/test_native_upload.py
+++ b/tests/integration/test_native_upload.py
@@ -106,7 +106,6 @@ class TestNativeUpload:
             assert len(files) == 3
             assert sorted([file["label"] for file in files]) == sorted(expected_files)
 
-
     def test_native_upload_by_handler(
         self,
         credentials,
@@ -116,8 +115,16 @@ class TestNativeUpload:
         # Arrange
         byte_string = b"Hello, World!"
         files = [
-            File(filepath="subdir/file.txt", handler=BytesIO(byte_string)),
-            File(filepath="biggerfile.txt", handler=BytesIO(byte_string*10000)),
+            File(
+                filepath="subdir/file.txt",
+                handler=BytesIO(byte_string),
+                description="This is a test",
+            ),
+            File(
+                filepath="biggerfile.txt",
+                handler=BytesIO(byte_string * 10000),
+                description="This is a test",
+            ),
         ]
 
         # Create Dataset
@@ -154,5 +161,14 @@ class TestNativeUpload:
 
             file = next(file for file in files if file["label"] == ex_f)
 
-            assert file["label"] == ex_f, f"File label does not match for file {json.dumps(file)}"
-            assert file.get("directoryLabel", "") == ex_dir, f"Directory label does not match for file {json.dumps(file)}"
+            assert (
+                file["label"] == ex_f
+            ), f"File label does not match for file {json.dumps(file)}"
+
+            assert (
+                file.get("directoryLabel", "") == ex_dir
+            ), f"Directory label does not match for file {json.dumps(file)}"
+
+            assert (
+                file["description"] == "This is a test"
+            ), f"Description does not match for file {json.dumps(file)}"


### PR DESCRIPTION
**Overview**

This pull request adds functionality to update file metadata after uploading ZIP archives via DVUploader. Currently, Dataverse can upload multiple files as ZIP archives, but this process results in the loss of any file metadata. This pull request introduces a step after the native upload to update the metadata for each file accordingly.

**TLDR**

* Adds metadata to files after zipped native upload
* Extended tests to check if description is properly set