### PR TITLE
Custom filenames upon upload

### DIFF
--- a/dvuploader/file.py
+++ b/dvuploader/file.py
@@ -74,7 +74,9 @@ class File(BaseModel):
             self.directory_label = os.path.dirname(self.filepath)
             self.handler.seek(0)
 
-        self.file_name = os.path.basename(self.filepath)
+        if self.file_name is None:
+            self.file_name = os.path.basename(self.filepath)
+
         self.checksum = Checksum.from_file(
             handler=self.handler,
             hash_fun=hash_fun,


### PR DESCRIPTION
This PR adds the ability to specify a different file name within a `File` object to be displayed at a Dataverse instance. This is independent of the actual file name found in `filepath` and overrides the default to use the base name of the latter.

**Example**

```python
import dvuploader as dv

files = [
    dv.File(
        filepath="test.py",
        file_name="this_is_different.py",
    ),
]
```

Upon upload, the file `test.py` will be displayed at Dataverse as `this_is_different.py`.

Closes #14 