### PR TITLE
Parallel hash calculation and progress bar fix

### DIFF
--- a/dvuploader/checksum.py
+++ b/dvuploader/checksum.py
@@ -1,6 +1,5 @@
 import hashlib
 from enum import Enum
-from types import NoneType
 from typing import IO, Callable
 from pydantic.fields import PrivateAttr
 from typing_extensions import Optional

--- a/dvuploader/directupload.py
+++ b/dvuploader/directupload.py
@@ -204,7 +204,7 @@ async def _request_ticket(
         size=file_size,
     )
 
-    response = await session.get(url)
+    response = await session.get(url, timeout=None)
     response.raise_for_status()
 
     return response.json()["data"]

--- a/dvuploader/directupload.py
+++ b/dvuploader/directupload.py
@@ -6,7 +6,7 @@ import os
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urljoin
 import aiofiles
-from typing import AsyncGenerator, Callable
+from typing import AsyncGenerator
 from rich.progress import Progress, TaskID
 
 from dvuploader.file import File
@@ -16,9 +16,9 @@ TESTING = bool(os.environ.get("DVUPLOADER_TESTING", False))
 MAX_FILE_DISPLAY = int(os.environ.get("DVUPLOADER_MAX_FILE_DISPLAY", 50))
 MAX_RETRIES = int(os.environ.get("DVUPLOADER_MAX_RETRIES", 10))
 
-assert isinstance(
-    MAX_FILE_DISPLAY, int
-), "DVUPLOADER_MAX_FILE_DISPLAY must be an integer"
+assert isinstance(MAX_FILE_DISPLAY, int), (
+    "DVUPLOADER_MAX_FILE_DISPLAY must be an integer"
+)
 
 assert isinstance(MAX_RETRIES, int), "DVUPLOADER_MAX_RETRIES must be an integer"
 
@@ -628,7 +628,6 @@ async def _multipart_json_data_request(
         )
 
 
-
 async def upload_bytes(
     file: BytesIO,
     progress: Progress,
@@ -647,7 +646,6 @@ async def upload_bytes(
     """
     while True:
         data = file.read(1024 * 1024)  # 1MB
-
 
         if not data:
             break

--- a/dvuploader/dvuploader.py
+++ b/dvuploader/dvuploader.py
@@ -6,7 +6,7 @@ import rich
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel
-from rich.progress import Progress, TaskID
+from rich.progress import Progress
 from rich.table import Table
 from rich.console import Console
 from rich.panel import Panel
@@ -232,7 +232,6 @@ class DVUploader(BaseModel):
                 f"\nSkipping {len(to_skip)} existing files. Use `replace_existing=True` to replace them.\n"
             )
             self.files = [file for file in self.files if not file.to_replace]
-
 
         if over_threshold:
             table = Table(title="[bold white]🔎 Checking dataset files")

--- a/dvuploader/file.py
+++ b/dvuploader/file.py
@@ -53,9 +53,9 @@ class File(BaseModel):
 
     _size: int = PrivateAttr(default=0)
 
-    def extract_file_name_hash_file(self):
+    def extract_file_name(self):
         """
-        Extracts the file_name and calculates the hash of the file.
+        Extracts the file name from the file path.
 
         Returns:
             self: The current instance of the class.
@@ -76,8 +76,7 @@ class File(BaseModel):
         if self.file_name is None:
             self.file_name = os.path.basename(self.filepath)
 
-        self.checksum = Checksum.from_file(
-            handler=self.handler,
+        self.checksum = Checksum.from_algo(
             hash_fun=hash_fun,
             hash_algo=hash_algo,
         )
@@ -100,3 +99,13 @@ class File(BaseModel):
             raise FileNotFoundError(f"Filepath {path} does not exist.")
         elif not os.path.isfile(path):
             raise IsADirectoryError(f"Filepath {path} is not a file.")
+
+    def apply_checksum(self):
+        assert self.checksum is not None, "Checksum is not calculated."
+        assert self.checksum._hash_fun is not None, "Checksum hash function is not set."
+
+        self.checksum.apply_checksum()
+
+    def __del__(self):
+        if self.handler is not None:
+            self.handler.close()

--- a/dvuploader/file.py
+++ b/dvuploader/file.py
@@ -10,10 +10,11 @@ from dvuploader.checksum import Checksum, ChecksumTypes
 
 class File(BaseModel):
     """
-    Represents a file with its properties and methods.
+    Represents a file with its properties and methods for uploading to Dataverse.
 
     Attributes:
         filepath (str): The path to the file.
+        handler (Union[BytesIO, StringIO, IO, None]): File handler for reading the file contents.
         description (str): The description of the file.
         directory_label (str): The label of the directory where the file is stored.
         mimeType (str): The MIME type of the file.
@@ -24,12 +25,15 @@ class File(BaseModel):
         file_name (Optional[str]): The name of the file.
         checksum (Optional[Checksum]): The checksum of the file.
         to_replace (bool): Indicates if the file should be replaced.
-        file_id (Optional[str]): The ID of the file.
+        file_id (Optional[Union[str, int]]): The ID of the file to replace.
+
+    Private Attributes:
+        _size (int): Size of the file in bytes.
 
     Methods:
+        extract_file_name(): Extracts filename from filepath and initializes file handler.
         _validate_filepath(path): Validates if the file path exists and is a file.
-        _extract_file_name_hash_file(): Extracts the file_name from the filepath and calculates the file's checksum.
-
+        apply_checksum(): Calculates and applies the checksum for the file.
     """
 
     model_config = ConfigDict(
@@ -55,7 +59,8 @@ class File(BaseModel):
 
     def extract_file_name(self):
         """
-        Extracts the file name from the file path.
+        Extracts the file name from the file path and initializes the file handler.
+        Also calculates the file size and prepares for checksum calculation.
 
         Returns:
             self: The current instance of the class.
@@ -93,7 +98,7 @@ class File(BaseModel):
 
         Raises:
             FileNotFoundError: If the filepath does not exist.
-            TypeError: If the filepath is not a file.
+            IsADirectoryError: If the filepath points to a directory instead of a file.
         """
         if not os.path.exists(path):
             raise FileNotFoundError(f"Filepath {path} does not exist.")
@@ -101,6 +106,13 @@ class File(BaseModel):
             raise IsADirectoryError(f"Filepath {path} is not a file.")
 
     def apply_checksum(self):
+        """
+        Calculates and applies the checksum for the file.
+        Must be called after extract_file_name() has initialized the checksum.
+
+        Raises:
+            AssertionError: If checksum is not initialized or hash function is not set.
+        """
         assert self.checksum is not None, "Checksum is not calculated."
         assert self.checksum._hash_fun is not None, "Checksum hash function is not set."
 

--- a/dvuploader/packaging.py
+++ b/dvuploader/packaging.py
@@ -21,7 +21,7 @@ def distribute_files(dv_files: List[File]):
         maximum_size (int, optional): The maximum size of each package in bytes. Defaults to 2 * 1024**3.
 
     Returns:
-        List[List[File]]: The distributed packages of files.
+        List[File]: The distributed packages of files.
     """
     packages = []
     current_package = []

--- a/dvuploader/utils.py
+++ b/dvuploader/utils.py
@@ -44,9 +44,10 @@ def retrieve_dataset_files(
     """
     Retrieve the files of a specific dataset from a Dataverse repository.
 
-    Parameters:
+    Args:
         dataverse_url (str): The base URL of the Dataverse repository.
         persistent_id (str): The persistent identifier (PID) of the dataset.
+        api_token (str): API token for authentication.
 
     Returns:
         list: A list of files in the dataset.
@@ -76,9 +77,9 @@ def add_directory(
     Recursively adds all files in the specified directory to a list of File objects.
 
     Args:
-        directory (str): The directory path.
+        directory (str): The directory path to scan for files.
         ignore (List[str], optional): A list of regular expressions to ignore certain files or directories. Defaults to [r"^\."].
-        rootDirectoryLabel (str, optional): The label to be added to the directory path of each file. Defaults to "".
+        rootDirectoryLabel (str, optional): The label to be prepended to the directory path of each file. Defaults to "".
 
     Returns:
         List[File]: A list of File objects representing the files in the directory.
@@ -114,14 +115,14 @@ def add_directory(
 
 def _truncate_path(path: pathlib.Path, to_remove: pathlib.Path):
     """
-    Truncate a path by removing a substring from the beginning.
+    Truncate a path by removing a prefix path.
 
     Args:
-        path (str): The path to truncate.
-        to_remove (str): The substring to remove from the beginning of the path.
+        path (pathlib.Path): The full path to truncate.
+        to_remove (pathlib.Path): The prefix path to remove.
 
     Returns:
-        str: The truncated path.
+        str: The truncated path as a string, or empty string if nothing remains after truncation.
     """
 
     parts = path.parts[len(to_remove.parts) :]
@@ -134,14 +135,14 @@ def _truncate_path(path: pathlib.Path, to_remove: pathlib.Path):
 
 def part_is_ignored(part, ignore):
     """
-    Check if a part should be ignored based on a list of patterns.
+    Check if a path part should be ignored based on a list of regex patterns.
 
     Args:
-        part (str): The part to check.
-        ignore (list): A list of patterns to match against.
+        part (str): The path part to check.
+        ignore (List[str]): A list of regex patterns to match against.
 
     Returns:
-        bool: True if the part should be ignored, False otherwise.
+        bool: True if the part matches any ignore pattern, False otherwise.
     """
     for pattern in ignore:
         if re.match(pattern, part):
@@ -154,14 +155,14 @@ def setup_pbar(
     progress: Progress,
 ) -> int:
     """
-    Set up a progress bar for a file.
+    Set up a progress bar for tracking file upload progress.
 
     Args:
-        fpath (str): The path to the file.
-        progress (Progress): The progress bar object.
+        file (File): The File object containing file information.
+        progress (Progress): The rich Progress instance for displaying progress.
 
     Returns:
-        int: The task ID of the progress bar.
+        int: The task ID for the created progress bar.
     """
 
     file_size = file._size

--- a/tests/integration/test_native_upload.py
+++ b/tests/integration/test_native_upload.py
@@ -157,17 +157,16 @@ class TestNativeUpload:
         assert len(files) == 2
 
         for ex_dir, ex_f in expected:
-
             file = next(file for file in files if file["label"] == ex_f)
 
-            assert (
-                file["label"] == ex_f
-            ), f"File label does not match for file {json.dumps(file)}"
+            assert file["label"] == ex_f, (
+                f"File label does not match for file {json.dumps(file)}"
+            )
 
-            assert (
-                file.get("directoryLabel", "") == ex_dir
-            ), f"Directory label does not match for file {json.dumps(file)}"
+            assert file.get("directoryLabel", "") == ex_dir, (
+                f"Directory label does not match for file {json.dumps(file)}"
+            )
 
-            assert (
-                file["description"] == "This is a test"
-            ), f"Description does not match for file {json.dumps(file)}"
+            assert file["description"] == "This is a test", (
+                f"Description does not match for file {json.dumps(file)}"
+            )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -14,7 +14,7 @@ class TestParseYAMLConfig:
 
         # Act
         cli_input = _parse_yaml_config(fpath)
-        [file.extract_file_name_hash_file() for file in cli_input.files]
+        [file.extract_file_name() for file in cli_input.files]
 
         # Assert
         expected_files = [

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -13,7 +13,7 @@ class TestFile:
             directory_label="",
         )
 
-        file.extract_file_name_hash_file()
+        file.extract_file_name()
 
         # Assert
         assert file.file_name == "somefile.txt"
@@ -29,7 +29,7 @@ class TestFile:
                 directory_label="",
             )
 
-            file.extract_file_name_hash_file()
+            file.extract_file_name()
 
     def test_read_non_file(self):
         # Arrange
@@ -42,4 +42,4 @@ class TestFile:
                 directory_label="",
             )
 
-            file.extract_file_name_hash_file()
+            file.extract_file_name()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -19,7 +19,7 @@ class TestAddDirectory:
 
         # Act
         files = add_directory(directory)
-        [file.extract_file_name_hash_file() for file in files]
+        [file.extract_file_name() for file in files]
 
         # Assert
         expected_files = [
@@ -33,14 +33,14 @@ class TestAddDirectory:
         assert len(files) == len(expected_files), "Wrong number of files"
 
         for directory_label, file_name in expected_files:
-            assert any(
-                file.file_name == file_name for file in files
-            ), f"File {file_name} not found in files"
+            assert any(file.file_name == file_name for file in files), (
+                f"File {file_name} not found in files"
+            )
 
             file = next(filter(lambda file: file.file_name == file_name, files))
-            assert (
-                file.directory_label == directory_label
-            ), f"File {file_name} has wrong directory label"
+            assert file.directory_label == directory_label, (
+                f"File {file_name} has wrong directory label"
+            )
 
     def test_all_files_added_except_hidden_and_dunder(self):
         # Arrange
@@ -48,7 +48,7 @@ class TestAddDirectory:
 
         # Act
         files = add_directory(directory, ignore=[r"^\.", "__.*__"])
-        [file.extract_file_name_hash_file() for file in files]
+        [file.extract_file_name() for file in files]
 
         # Assert
         expected_files = [
@@ -61,14 +61,14 @@ class TestAddDirectory:
         assert len(files) == len(expected_files), "Wrong number of files"
 
         for directory_label, file_name in expected_files:
-            assert any(
-                file.file_name == file_name for file in files
-            ), f"File {file_name} not found in files"
+            assert any(file.file_name == file_name for file in files), (
+                f"File {file_name} not found in files"
+            )
 
             file = next(filter(lambda file: file.file_name == file_name, files))
-            assert (
-                file.directory_label == directory_label
-            ), f"File {file_name} has wrong directory label"
+            assert file.directory_label == directory_label, (
+                f"File {file_name} has wrong directory label"
+            )
 
 
 class TestBuildUrl:


### PR DESCRIPTION
This pull request merges the process of uploading files and hashing them into a unified operation, so that both actions occur simultaneously rather than sequentially. It also fixes the issue where progress bars during direct uploads did not update properly by incorporating the `Content-Length` header.

Sneaked in docstring updates 🕵️‍♂️