### PR TITLE
Add CLI input checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Integration Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/dvuploader/cli.py
+++ b/dvuploader/cli.py
@@ -142,11 +142,6 @@ def main(
         $ dvuploader --config-path upload_config.yaml
     """
 
-    if not filepaths and not config_path:
-        raise typer.BadParameter(
-            "You must provide either a list of filepaths or a path to a configuration file via the --config-path option."
-        )
-
     if filepaths is None:
         filepaths = []
 

--- a/dvuploader/cli.py
+++ b/dvuploader/cli.py
@@ -90,7 +90,7 @@ def _validate_inputs(
 
 @app.command()
 def main(
-    filepaths: List[str] = typer.Argument(
+    filepaths: Optional[List[str]] = typer.Argument(
         default=None,
         help="A list of filepaths to upload.",
     ),
@@ -141,6 +141,15 @@ def main(
         Upload files via config file:
         $ dvuploader --config-path upload_config.yaml
     """
+
+    if not filepaths and not config_path:
+        raise typer.BadParameter(
+            "You must provide either a list of filepaths or a path to a configuration file via the --config-path option."
+        )
+
+    if filepaths is None:
+        filepaths = []
+
     _validate_inputs(
         filepaths=filepaths,
         pid=pid,


### PR DESCRIPTION
This PR addresses the issue where no file path args are provided, and only a YAML config file is given. It appears to relate to new `typer` versions, which may not supply default factories when no input is given. This results in a `None` value rather than an empty list and breaks the code.