### PR TITLE
Use raw docstring in order to avoid invalid escape sequence

### DIFF
--- a/dvuploader/utils.py
+++ b/dvuploader/utils.py
@@ -73,7 +73,7 @@ def add_directory(
     ignore: List[str] = [r"^\."],
     rootDirectoryLabel: str = "",
 ):
-    """
+    r"""
     Recursively adds all files in the specified directory to a list of File objects.
 
     Args:


### PR DESCRIPTION
Should fix #32 