### PR TITLE
Native upload: Handle file replacements and metadata updates.

### DIFF
--- a/dvuploader/dvuploader.py
+++ b/dvuploader/dvuploader.py
@@ -240,8 +240,6 @@ class DVUploader(BaseModel):
 
                 if replace_existing:
                     ds_file = self._get_dsfile_by_id(file.file_id, ds_files)
-                    # calculate size and initialize hash function
-                    file.extract_file_name()
                     if not self._check_size(file, ds_file):
                         file._unchanged_data = False
                     else:

--- a/dvuploader/dvuploader.py
+++ b/dvuploader/dvuploader.py
@@ -239,9 +239,24 @@ class DVUploader(BaseModel):
                 to_skip.append(file.file_id)
 
                 if replace_existing:
-                    table.add_row(
-                        file.file_name, "[bright_cyan]Exists", "[bright_black]Replace"
-                    )
+                    ds_file = self._get_dsfile_by_id(file.file_id, ds_files)
+                    # calculate size and initialize hash function
+                    file.extract_file_name()
+                    if not self._check_size(file, ds_file):
+                        file._unchanged_data = False
+                    else:
+                        # calculate checksum
+                        file.update_checksum_chunked()
+                        file.apply_checksum()
+                        file._unchanged_data = self._check_hashes(file, ds_file)
+                    if file._unchanged_data:
+                        table.add_row(
+                            file.file_name, "[bright_cyan]Exists", "[bright_black]Replace Meta"
+                        )
+                    else:
+                        table.add_row(
+                            file.file_name, "[bright_cyan]Exists", "[bright_black]Replace"
+                        )
                 else:
                     table.add_row(
                         file.file_name, "[bright_cyan]Exists", "[bright_black]Skipping"
@@ -295,6 +310,25 @@ class DVUploader(BaseModel):
                 return ds_file["dataFile"]["id"]
 
     @staticmethod
+    def _get_dsfile_by_id(
+        file_id: int,
+        ds_files: List[Dict],
+    ) -> Optional[Dict]:
+        """
+        Retrieves a dataset file dictionary by its ID.
+
+        Args:
+            file_id (int): The ID of the file to retrieve.
+            ds_files (List[Dict]): List of dictionary objects representing dataset files.
+
+        Returns:
+            Optional[Dict]: The dataset file dictionary if found, None otherwise.
+        """
+        for ds_file in ds_files:
+            if ds_file["dataFile"]["id"] == file_id:
+                return ds_file
+
+    @staticmethod
     def _check_hashes(file: File, dsFile: Dict):
         """
         Checks if a file has the same checksum as a file in the dataset.
@@ -320,6 +354,20 @@ class DVUploader(BaseModel):
             and file.checksum.type == hash_algo
             and path == os.path.join(file.directory_label, file.file_name)  # type: ignore
         )
+
+    @staticmethod
+    def _check_size(file: File, dsFile: Dict) -> bool:
+        """
+        Checks if the file size matches the size of the file in the dataset.
+
+        Args:
+            file (File): The file to check.
+            dsFile (Dict): The file in the dataset to compare against.
+
+        Returns:
+            bool: True if the sizes match, False otherwise.
+        """
+        return dsFile["dataFile"]["filesize"] == file._size
 
     @staticmethod
     def _has_direct_upload(

--- a/dvuploader/nativeupload.py
+++ b/dvuploader/nativeupload.py
@@ -421,7 +421,6 @@ async def _update_single_metadata(
     json_data = _get_json_data(file)
 
     del json_data["forceReplace"]
-    del json_data["restrict"]
 
     # Send metadata as a readable byte stream
     # This is a workaround since "data" and "json"

--- a/dvuploader/nativeupload.py
+++ b/dvuploader/nativeupload.py
@@ -182,7 +182,6 @@ def _zip_packages(
     for index, package in packages:
         if len(package) == 1:
             file = package[0]
-            file.extract_file_name()
             pbar = progress.add_task(
                 file.file_name,  # type: ignore
                 total=file._size,

--- a/dvuploader/nativeupload.py
+++ b/dvuploader/nativeupload.py
@@ -91,14 +91,29 @@ async def native_upload(
         "proxy": proxy,
     }
 
+    files_new = [file for file in files if not file.to_replace]
+    files_new_metadata = [file for file in files if file.to_replace and file._unchanged_data]
+    files_replace = [file for file in files if file.to_replace and not file._unchanged_data]
+
     async with httpx.AsyncClient(**session_params) as session:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            packages = distribute_files(files)
+            packages = distribute_files(files_new)
             packaged_files = _zip_packages(
                 packages=packages,
                 tmp_dir=tmp_dir,
                 progress=progress,
             )
+
+            replacable_files = [
+                (
+                    progress.add_task(
+                        file.file_name,  # type: ignore
+                        total=file._size,
+                    ),
+                    file
+                )
+                for file in files_replace
+            ]
 
             tasks = [
                 _single_native_upload(
@@ -108,7 +123,7 @@ async def native_upload(
                     pbar=pbar,  # type: ignore
                     progress=progress,
                 )
-                for pbar, file in packaged_files
+                for pbar, file in (packaged_files + replacable_files)
             ]
 
             responses = await asyncio.gather(*tasks)
@@ -116,7 +131,7 @@ async def native_upload(
 
             await _update_metadata(
                 session=session,
-                files=files,
+                files=files_new + files_new_metadata,
                 persistent_id=persistent_id,
                 dataverse_url=dataverse_url,
                 api_token=api_token,
@@ -167,6 +182,11 @@ def _zip_packages(
     for index, package in packages:
         if len(package) == 1:
             file = package[0]
+            file.extract_file_name()
+            pbar = progress.add_task(
+                file.file_name,  # type: ignore
+                total=file._size,
+            )
         else:
             path = zip_files(
                 files=package,
@@ -178,10 +198,10 @@ def _zip_packages(
             file.extract_file_name()
             file.mimeType = "application/zip"
 
-        pbar = progress.add_task(
-            file.file_name,  # type: ignore
-            total=file._size,
-        )
+            pbar = progress.add_task(
+                f"Zip package of {len(package)} files",  # type: ignore
+                total=file._size,
+            )
 
         files.append((pbar, file))
 


### PR DESCRIPTION
This PR addresses two limitations of the Native API uploader:

* The Native API does not allow to replace files with the same file content:

```python
>>> import requests
... import json
... from pprint import pprint
...
... from dvuploader.utils import retrieve_dataset_files
...
... # this is used for the API url and the api_token
... from sdc_darus import config as cfg
...
>>> filename='randomdata.bin'
>>>
KeyboardInterrupt
>>>
(.darusvenv) [ben@skylab:~/Engineering/src/darus]%                                                                                                                       [0]
(.darusvenv) [ben@skylab:~/Engineering/src/darus]% python                                                                                                                [0]
Python 3.13.5 (main, Jun 11 2025, 22:06:31) [GCC] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests
... import json
... from pprint import pprint
...
... from dvuploader.utils import retrieve_dataset_files
...
... # this is used for the API url and the api_token
... from sdc_darus import config as cfg
...
>>> # Check the current content of the dataset:
>>> dspid = 'doi:10.80827/DARUS-2450'
... dsfiles = retrieve_dataset_files(cfg.darus_url, dspid, cfg.api_token)
... pprint(dsfiles)
...
[{'dataFile': {'checksum': {'type': 'MD5',
                            'value': 'f9014100615fe884ed8ec779e60b6021'},
               'contentType': 'application/octet-stream',
               'creationDate': '2025-08-05',
               'description': 'random data initially',
               'fileAccessRequest': False,
               'filename': 'randomdata.bin',
               'filesize': 2048,
               'friendlyType': 'Unknown',
               'id': 16878,
               'md5': 'f9014100615fe884ed8ec779e60b6021',
               'persistentId': 'doi:10.80827/DARUS-2450/1',
               'pidURL': 'https://doi.org/10.80827/DARUS-2450/1',
               'rootDataFileId': -1,
               'storageIdentifier': 's3://dv-stage-1:1987c03afac-baa9f8fa84bd',
               'tabularData': False},
  'datasetVersionId': 2298,
  'description': 'random data initially',
  'label': 'randomdata.bin',
  'restricted': False,
  'version': 1}]
>>> # Replace it with some new data:
... with open('randomdata2.bin',"rb") as fh:
...     file_content = fh.read()
...
>>> filename = dsfiles[0]['dataFile']['filename']
... pid = dsfiles[0]['dataFile']['persistentId']
... contenttype = dsfiles[0]['dataFile']['contentType']
... metadata = {
...     'description': 'This has now new content',
...     'categories': ['Some', 'new', 'tags'],
... }
...
>>> s = requests.Session()
... s.headers.update({'X-Dataverse-key': cfg.api_token})
... r = s.post(
...     f"{cfg.darus_url}api/files/:persistentId/replace",
...     params={'persistentId': pid},
...     files={'jsonData': json.dumps(metadata),
...            'file': (filename, file_content, contenttype)})
...
>>> # This worked, because it is new data
>>> r.status_code
200
>>> pprint(r.text)
('{"status":"OK","data":{"files":[{"description":"This has now new '
 'content","label":"randomdata.bin","restricted":false,"version":1,"datasetVersionId":2298,"categories":["new","Some","tags"],"dataFile":{"id":16879,"persistentId":"doi:10.80827/DARUS-2450/1","pidURL":"https://doi.org/10.80827/DARUS-2450/1","filename":"randomdata.bin","contentType":"application/octet-stream","friendlyType":"Unknown","filesize":2048,"description":"This '
 'has now new '
 'content","categories":["new","Some","tags"],"storageIdentifier":"s3://dv-stage-1:1987c079792-8da0ba16dcd3","rootDataFileId":-1,"md5":"013d018061b5c200f34d51bd159178d2","checksum":{"type":"MD5","value":"013d018061b5c200f34d51bd159178d2"},"tabularData":false,"creationDate":"2025-08-05","fileAccessRequest":false}}]}}')
>>> # Now try again with new metadata but same content
>>> metadata['description'] = 'We have new metadata!'
... r = s.post(
...     f"{cfg.darus_url}api/files/:persistentId/replace",
...     params={'persistentId': pid},
...     files={'jsonData': json.dumps(metadata),
...            'file': (filename, file_content, contenttype)})
... r.status_code
...
400
>>> pprint(r.text)
('{"status":"ERROR","message":"Error! You may not replace a file with a file '
 'that has duplicate content."}')
>>>
```

With this PR, the code checks if the file content has the same hash and only updates the metadata in this case.

* When Uploading as a zipped package, files do not get replaced but added with a `-N.ext` filename

With this PR, the code uploads the files to be replaced with new content individually instead of with a zipped package.

Example Output:


<img width="862" height="727" alt="image" src="https://github.com/user-attachments/assets/d6e31a98-62be-4a55-868b-7e7653226cdc" />


Also, the `restricted` property of a file should not get lost, when updating the metadata.