### PR TITLE
Update `API_TOKEN` export example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ docker compose \
 
 ```bash
 export BASE_URL=http://localhost:8080
-export $(grep "API_TOKEN" "dv/bootstrap.exposed.env")
+export API_TOKEN=XXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
 export DVUPLOADER_TESTING=true
 ```
 


### PR DESCRIPTION
This pull request is related to #41 and makes a small change to the `README.md` file, updating the instructions for setting the `API_TOKEN` environment variable to use a placeholder value instead of reading it from a file. Replaces the grep-based API_TOKEN export with a direct assignment for clarity in the setup instructions.