### PR TITLE
Open files just-in-time to prevent `OSError`

### DIFF
--- a/dvuploader/directupload.py
+++ b/dvuploader/directupload.py
@@ -250,7 +250,7 @@ async def _upload_singlepart(
         "headers": headers,
         "url": ticket["url"],
         "content": upload_bytes(
-            file=file.handler,  # type: ignore
+            file=file.get_handler(),  # type: ignore
             progress=progress,
             pbar=pbar,
             hash_func=file.checksum._hash_fun,

--- a/dvuploader/file.py
+++ b/dvuploader/file.py
@@ -78,7 +78,6 @@ class File(BaseModel):
 
         if self.handler is None:
             self._validate_filepath(self.filepath)
-            self.handler = open(self.filepath, "rb")
             self._size = os.path.getsize(self.filepath)
         else:
             self._size = len(self.handler.read())
@@ -94,6 +93,15 @@ class File(BaseModel):
         )
 
         return self
+
+    def get_handler(self) -> IO:
+        """
+        Opens the file and initializes the file handler.
+        """
+        if self.handler is not None:
+            return self.handler
+
+        return open(self.filepath, "rb")
 
     @staticmethod
     def _validate_filepath(path):
@@ -126,7 +134,6 @@ class File(BaseModel):
 
         self.checksum.apply_checksum()
 
-
     def update_checksum_chunked(self, blocksize=2**20):
         """Updates the checksum with data read from a file-like object in chunks.
 
@@ -139,12 +146,13 @@ class File(BaseModel):
         Note:
             This method resets the file position to the start after reading.
         """
-        assert self.handler is not None, "File handler is not initialized."
         assert self.checksum is not None, "Checksum is not initialized."
         assert self.checksum._hash_fun is not None, "Checksum hash function is not set."
 
+        handler = self.get_handler()
+
         while True:
-            buf = self.handler.read(blocksize)
+            buf = handler.read(blocksize)
 
             if not isinstance(buf, bytes):
                 buf = buf.encode()
@@ -153,8 +161,12 @@ class File(BaseModel):
                 break
             self.checksum._hash_fun.update(buf)
 
-        self.handler.seek(0)
-
+        if self.handler is not None:  # type: ignore
+            # In case of passed handler, we need to seek the handler to the start after reading.
+            self.handler.seek(0)
+        else:
+            # Path-based handlers will be opened just-in-time, so we can close it.
+            handler.close()
 
     def __del__(self):
         if self.handler is not None:

--- a/dvuploader/nativeupload.py
+++ b/dvuploader/nativeupload.py
@@ -92,8 +92,12 @@ async def native_upload(
     }
 
     files_new = [file for file in files if not file.to_replace]
-    files_new_metadata = [file for file in files if file.to_replace and file._unchanged_data]
-    files_replace = [file for file in files if file.to_replace and not file._unchanged_data]
+    files_new_metadata = [
+        file for file in files if file.to_replace and file._unchanged_data
+    ]
+    files_replace = [
+        file for file in files if file.to_replace and not file._unchanged_data
+    ]
 
     # These are not in a package but need a metadtata update, ensure even for zips
     for file in files_new_metadata:
@@ -114,7 +118,7 @@ async def native_upload(
                         file.file_name,  # type: ignore
                         total=file._size,
                     ),
-                    file
+                    file,
                 )
                 for file in files_replace
             ]
@@ -269,11 +273,12 @@ async def _single_native_upload(
         )
 
     json_data = _get_json_data(file)
+    handler = file.get_handler()
 
     files = {
         "file": (
             file.file_name,
-            file.handler,
+            handler,
             file.mimeType,
         ),
         "jsonData": (
@@ -374,8 +379,10 @@ async def _update_metadata(
             if _tab_extension(dv_path) in file_mapping:
                 file_id = file_mapping[_tab_extension(dv_path)]
             elif (
-                file.file_name and _is_zip(file.file_name)
-                and not file._is_inside_zip and not file._enforce_metadata_update
+                file.file_name
+                and _is_zip(file.file_name)
+                and not file._is_inside_zip
+                and not file._enforce_metadata_update
             ):
                 # When the file is a zip package it will be unpacked and thus
                 # the expected file name of the zip will not be in the

--- a/dvuploader/packaging.py
+++ b/dvuploader/packaging.py
@@ -95,7 +95,7 @@ def zip_files(
     with zipfile.ZipFile(path, "w") as zip_file:
         for file in files:
             zip_file.writestr(
-                data=file.handler.read(),  # type: ignore
+                data=file.get_handler().read(),  # type: ignore
                 zinfo_or_arcname=_create_arcname(file),
             )
             file._is_inside_zip = True


### PR DESCRIPTION
This pull request addresses issue #40, which has been documented. When the number of open files exceeds a certain limit, Python raises an `OSError` indicating an overflow. Previously, the implementation opened files as handlers during `File` initialization, which resulted in this error when the number of open files exceeded the OS's limit. 

This PR refactors file handler management across several modules to improve reliability and consistency when accessing file data. The main change introduces a new `get_handler` method in the `File` class to standardize how file handlers are obtained, ensuring files are opened only when needed and properly closed after use. This update affects file reading, uploading, packaging, and checksum operations.

**File handler management and API consistency:**

* Added a `get_handler` method to the `File` class in `dvuploader/file.py`, which opens the file if the handler is not already set, centralizing file handler access logic.
* Updated all usages of direct `file.handler` access in `dvuploader/directupload.py`, `dvuploader/nativeupload.py`, and `dvuploader/packaging.py` to use `file.get_handler()`, ensuring consistent file opening and closing behavior. [[1]](diffhunk://#diff-1c608ecb148fb0699b050a2bb2b2dfefea90c06f73eb90dd8171fc09cd8a269dL253-R253) [[2]](diffhunk://#diff-2caa98cae43656e2689a872e2cef8d09d313dd1b8db523768b02a742fd93d6feR276-R281) [[3]](diffhunk://#diff-b9dd641bfc84d466ea86e28375b99a91f2fadbc1b400fe7688a959c6d4e344f1L98-R98)

**Checksum and file reading improvements:**

* Refactored `update_checksum_chunked` in `dvuploader/file.py` to use `get_handler()` for reading file data, and added logic to reset or close handlers depending on how they were obtained. [[1]](diffhunk://#diff-0a1833a7d564b0ede4145a1a635680e9e799a2b81c29cb490719173c06c85189L142-R155) [[2]](diffhunk://#diff-0a1833a7d564b0ede4145a1a635680e9e799a2b81c29cb490719173c06c85189R164-R169)
* Removed the assertion that required `self.handler` to be initialized before updating checksum, allowing for just-in-time file opening.

**Closes issues**

* closes #40