### PR TITLE
31 is tab ingest setting missing in  get json data

### DIFF
--- a/dvuploader/file.py
+++ b/dvuploader/file.py
@@ -44,20 +44,72 @@ class File(BaseModel):
         arbitrary_types_allowed=True,
     )
 
-    filepath: str = Field(..., exclude=True)
-    handler: Union[BytesIO, StringIO, IO, None] = Field(default=None, exclude=True)
-    description: str = ""
-    directory_label: str = Field(default="", alias="directoryLabel")
-    mimeType: str = "application/octet-stream"
-    categories: Optional[List[str]] = ["DATA"]
-    restrict: bool = False
-    checksum_type: ChecksumTypes = Field(default=ChecksumTypes.MD5, exclude=True)
-    storageIdentifier: Optional[str] = None
-    file_name: Optional[str] = Field(default=None, alias="fileName")
-    checksum: Optional[Checksum] = None
-    to_replace: bool = False
-    file_id: Optional[Union[str, int]] = Field(default=None, alias="fileToReplaceId")
-    tab_ingest: bool = Field(default=True, alias="tabIngest")
+    filepath: str = Field(
+        ...,
+        exclude=True,
+        description="The path to the file",
+    )
+    handler: Union[BytesIO, StringIO, IO, None] = Field(
+        default=None,
+        exclude=True,
+        description="File handler for reading the file contents",
+    )
+    description: Optional[str] = Field(
+        default=None,
+        alias="description",
+        description="The description of the file",
+    )
+    directory_label: Optional[str] = Field(
+        default=None,
+        alias="directoryLabel",
+        description="The label of the directory where the file is stored",
+    )
+    mimeType: str = Field(
+        default="application/octet-stream",
+        description="The MIME type of the file",
+    )
+    categories: Optional[List[str]] = Field(
+        default=["DATA"],
+        alias="categories",
+        description="The categories associated with the file",
+    )
+    restrict: bool = Field(
+        default=False,
+        alias="restrict",
+        description="Indicates if the file is restricted",
+    )
+    checksum_type: ChecksumTypes = Field(
+        default=ChecksumTypes.MD5,
+        exclude=True,
+        description="The type of checksum used for the file",
+    )
+    storageIdentifier: Optional[str] = Field(
+        default=None,
+        description="The identifier of the storage where the file is stored",
+    )
+    file_name: Optional[str] = Field(
+        default=None,
+        alias="fileName",
+        description="The name of the file",
+    )
+    checksum: Optional[Checksum] = Field(
+        default=None,
+        description="The checksum of the file",
+    )
+    file_id: Optional[Union[str, int]] = Field(
+        default=None,
+        alias="fileToReplaceId",
+        description="The ID of the file to replace",
+    )
+    tab_ingest: bool = Field(
+        default=True,
+        alias="tabIngest",
+        description="Indicates if tabular ingest should be performed",
+    )
+    to_replace: bool = Field(
+        default=False,
+        description="Indicates if the file should be replaced",
+    )
 
     _size: int = PrivateAttr(default=0)
     _unchanged_data: bool = PrivateAttr(default=False)
@@ -126,7 +178,6 @@ class File(BaseModel):
 
         self.checksum.apply_checksum()
 
-
     def update_checksum_chunked(self, blocksize=2**20):
         """Updates the checksum with data read from a file-like object in chunks.
 
@@ -154,7 +205,6 @@ class File(BaseModel):
             self.checksum._hash_fun.update(buf)
 
         self.handler.seek(0)
-
 
     def __del__(self):
         if self.handler is not None:

--- a/tests/unit/test_directupload.py
+++ b/tests/unit/test_directupload.py
@@ -4,6 +4,7 @@ from rich.progress import Progress
 from dvuploader.directupload import (
     _add_files_to_ds,
     _validate_ticket_response,
+    _prepare_registration,
 )
 
 from dvuploader.file import File
@@ -128,3 +129,50 @@ class Test_ValidateTicketResponse:
         }
         with pytest.raises(AssertionError):
             _validate_ticket_response(response)
+
+
+class TestPrepareRegistration:
+    def test_tab_ingest_is_set_correctly(self):
+        files = [
+            File(filepath="tests/fixtures/add_dir_files/somefile.txt"),
+            File(
+                filepath="tests/fixtures/add_dir_files/somefile.txt",
+                tab_ingest=False,  # type: ignore
+            ),
+            File(
+                filepath="tests/fixtures/add_dir_files/somefile.txt",
+                restrict=True,
+            ),
+            File(
+                filepath="tests/fixtures/add_dir_files/somefile.txt",
+                categories=["Test file"],
+            ),
+        ]
+        registration = _prepare_registration(files, use_replace=False)
+        expected_registration = [
+            {
+                "categories": ["DATA"],
+                "mimeType": "application/octet-stream",
+                "restrict": False,
+                "tabIngest": True,
+            },
+            {
+                "categories": ["DATA"],
+                "mimeType": "application/octet-stream",
+                "restrict": False,
+                "tabIngest": False,
+            },
+            {
+                "categories": ["DATA"],
+                "mimeType": "application/octet-stream",
+                "restrict": True,
+                "tabIngest": True,
+            },
+            {
+                "categories": ["Test file"],
+                "mimeType": "application/octet-stream",
+                "restrict": False,
+                "tabIngest": True,
+            },
+        ]
+        assert registration == expected_registration


### PR DESCRIPTION
This pull request addresses issue #31, which accurately pointed out that `tabIngest` is not passed as an argument to the `_get_json_data` private function. This PR introduces a generic solution that aligns with the direct-upload mechanism. In this approach, the `model_dump` of the underlying PyDantic object is utilized. This way, manual `jsonData` setup is eliminated and controlled by the `File` class.

**Upload logic and metadata handling:**

* Updated the `_get_json_data` function in `dvuploader/nativeupload.py` to use `model_dump` with a defined set of fields, replacing manual dictionary construction and ensuring only relevant metadata is included.
* Removed the unused `forceReplace` field from the metadata payload in `_update_single_metadata`.

**Test coverage:**

* Added a new test class `TestPrepareRegistration` in `tests/unit/test_directupload.py` to verify that the `tab_ingest` and other metadata fields are set correctly when preparing file registration, ensuring correct model behavior. [[1]](diffhunk://#diff-9d9cdd36b3872d3e0c9d46017b4a5f3fb05ce6f2e63961c93e0dc83f6d18a9a1R132-R178) [[2]](diffhunk://#diff-9d9cdd36b3872d3e0c9d46017b4a5f3fb05ce6f2e63961c93e0dc83f6d18a9a1R7)