### PR TITLE
Fix for single file native upload: directory path gets lost

### DIFF
--- a/dvuploader/nativeupload.py
+++ b/dvuploader/nativeupload.py
@@ -396,6 +396,7 @@ def _get_json_data(file: File) -> Dict:
         "categories",
         "restrict",
         "tabIngest",
+        "directory_label"
     }
     return file.model_dump(by_alias=True, exclude_none=True, include=include)
 

--- a/tests/integration/test_native_upload.py
+++ b/tests/integration/test_native_upload.py
@@ -590,6 +590,73 @@ class TestNativeUpload:
                 dataverse_url=BASE_URL,
                 n_parallel_uploads=1,
             )
+        
+    def test_native_upload_single_file_with_path(
+        self,
+        credentials,
+    ):
+
+        BASE_URL,  API_TOKEN = credentials
+
+        filename  = "single_file.bin"
+        dv_path = "a/b/c"
+        categories =  ["testfile", "with metadata"]
+        description = "This is a testfile with metadata"
+
+        # Create Dataset
+        pid = create_dataset(
+            parent="Root",
+            server_url=BASE_URL,
+            api_token=API_TOKEN,
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            os.makedirs(os.path.join(directory, dv_path))
+            local_path = os.path.join(directory, dv_path, filename)
+            self._create_file(1024*2, local_path)
+
+            files = [
+                File(
+                    filepath=local_path,
+                    directoryLabel=dv_path,
+                    categories=categories,
+                    description=description,
+                ),
+            ]
+
+            uploader = DVUploader(files=files)
+            uploader.upload(
+                persistent_id=pid,
+                api_token=API_TOKEN,
+                dataverse_url=BASE_URL,
+                n_parallel_uploads=1,
+            )
+
+        files = retrieve_dataset_files(
+            dataverse_url=BASE_URL,
+            persistent_id=pid,
+            api_token=API_TOKEN,
+        )
+
+        expected_files = [
+            {
+                "label": filename,
+                "directoryLabel": dv_path,
+                "description": description,
+                "categories": categories,
+            }
+        ]
+
+        files_as_expected = sorted(  # pyright: ignore[reportCallIssue]
+            [
+                {k: (f[k] if k in f else None) for k in expected_files[0].keys()}
+                for f in files
+            ],
+            key=lambda x: x["label"],  # pyright: ignore[reportArgumentType]
+        )
+        assert files_as_expected == expected_files, (
+            f"File metadata not as expected: {json.dumps(files, indent=2)}"
+        )        
 
     def _create_file(self, size: int, path: str):
         with open(path, "wb") as f:


### PR DESCRIPTION
When uploading a single file with a directory label, this gets lost in the native upload:

```
╭────────────── DVUploader ──────────────╮
│ Server: https://darus.uni-stuttgart.de │
│ PID: doi:10.18419/DARUS-6027           │
│ Files: 1                               │
╰────────────────────────────────────────╯
🔎 Checking dataset files
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┓
┃ File                                                   ┃ Status ┃ Action ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━┩
│ SOF-DWG-MM-1260.0.00 R01 Reference Mirror Assembly.pdf │ New    │ Upload │
└────────────────────────────────────────────────────────┴────────┴────────┘

⚠  Direct upload not supported. Falling back to Native API.

🚀 Uploading files

DEBUG: file=File(filepath='ta-library/1000 Optical Assembly/1200 Secondary Mirror Assembly/1260 SM Reference Mirror SMRM/_DWG/SOF-DWG-MM-1260.0.00 R01 Reference Mirror
Assembly.pdf', handler=None, description='SOF-DWG-MM-1260.0.00, Document Iteration No. 1 (Max: 1)', directory_label='1000 Optical Assembly/1200 Secondary Mirror Assembly/1260 SM
Reference Mirror SMRM/_DWG', mimeType='application/octet-stream', categories=['Lifecycle State: Released', 'TA Level 1: OA', 'TA Level 0: TA', 'TA Level 3: SMRM', 'Drawing', 'TA
Level 2: SMA', 'Company: Astrium', 'Document Iteration: Most Recent'], restrict=True, checksum_type=<ChecksumTypes.MD5: ('MD5', <built-in function openssl_md5>)>,
storageIdentifier=None, file_name='SOF-DWG-MM-1260.0.00 R01 Reference Mirror Assembly.pdf', checksum=Checksum(type='MD5', value=None), file_id=None, tab_ingest=True,
to_replace=False)
DEBUG: json_data={'description': 'SOF-DWG-MM-1260.0.00, Document Iteration No. 1 (Max: 1)', 'categories': ['Lifecycle State: Released', 'TA Level 1: OA', 'TA Level 0: TA', 'TA Level
3: SMRM', 'Drawing', 'TA Level 2: SMA', 'Company: Astrium', 'Document Iteration: Most Recent'], 'restrict': True}
(
    'File 1000 Optical Assembly/1200 Secondary Mirror Assembly/1260 SM Reference Mirror SMRM/_DWG/SOF-DWG-MM-1260.0.00 R01 Reference Mirror Assembly.pdf not found in Dataverse
repository.',
    'This may be due to the file not being uploaded to the repository:'
)
SOF-DWG-MM-1260.0.00 R01 Reference Mirror Assembly.pdf ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00

✅ Upload complete
```